### PR TITLE
[go-monorepo] Use gofumpt for formatting

### DIFF
--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -4,6 +4,7 @@
   "packages": {
     "go": "latest",
     "golangci-lint": "latest",
+    "runx:mvdan/gofumpt": "latest",
   },
   "env": {
     "GOENV": "off",
@@ -32,7 +33,7 @@
       "build": "for_each_gomod go build -v ./...",
       // TODO: fmt and lint is not correctly running on all projects.
       // Some projects need "devbox run fmt" and "devbox run lint".
-      "fmt": "for_each_gomod go fmt ./...",
+      "fmt": "find . -name '*.go' -not -path '*/gen/*' -exec gofumpt -w -l {} \\+",
       "lint": "for_each_gomod golangci-lint run --timeout 300s",
       "test": "for_each_gomod go test -race -cover -v ./...",
     }


### PR DESCRIPTION
Switch to using `gofumpt` instead of `go fmt`. It's a bit stricter and maintains backward compatibility.