### PR TITLE
[easy][go-monorepo] Use runx for golangci-lint

### DIFF
--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -3,7 +3,7 @@
   "description": "Go monorepo plugin",
   "packages": {
     "go": "latest",
-    "golangci-lint": "latest",
+    "runx:golangci/golangci-lint": "latest",
     "runx:mvdan/gofumpt": "latest",
   },
   "env": {


### PR DESCRIPTION
the nix version is built with go 1.23 which causes issues when codebase is 1.24