### PR TITLE
Fix RabbitMQ README

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -32,7 +32,7 @@ This plugin creates the following helper files:
 
 This plugin sets the following environment variables:
 
-* **RABBITMQ_CONFIG_FILE** = {{.DevboxDir}}/conf.d
+* **RABBITMQ_CONFIG_FILES** = {{.DevboxDir}}/conf.d
 * **RABBITMQ_MNESIA_BASE** = {{.Virtenv}}/mnesia
 * **RABBITMQ_ENABLED_PLUGINS_FILE** = {{.DevboxDir}}/conf.d/enabled_plugins
 * **RABBITMQ_LOG_BASE** = {{.Virtenv}}/log


### PR DESCRIPTION
The RabbitMQ plugin sets the `$RABBITMQ_CONFIG_FILES` environment variable, not `$RABBITMQ_CONFIG_FILE`, as shown in `rabbitmq/plugin.json:6`.[1]

Both variables are documented in the official RabbitMQ Environment Variables guide.[2]

[1] https://github.com/jetify-com/devbox-plugins/blob/4aab8235eb412ff6997900969aed64158c4497c8/rabbitmq/plugin.json#L6
[2] https://www.rabbitmq.com/docs/relocate#environment-variables